### PR TITLE
Make url and baseurl relative

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,8 +2,8 @@ title:            Open Music Theory
 tagline:          Hybrid Pedagogy Publishing
 description:      "an open, interactive, online textbook for college music theory"
 #Comment out url when working locally to resolve base urls correctly
-url: http://hybrid-pedagogy.github.io/openmusictheory
-baseurl: http://hybrid-pedagogy.github.io/openmusictheory
+url: /openmusictheory
+baseurl: /openmusictheory
 #baseurl: /Users/krisshaffer/Websites/openmusictheory
 
 


### PR DESCRIPTION
Project's looking great!

One thing I discovered in using Github Pages for [my course last year](http://github.com/silshack/spring2014) is that you can get Github to automatically deploy a Github Pages site for anyone who forks the project.  The changes in this pull request to that for this project.

If `url` and `baseurl` are set to the repo's name (in this case `/openmusictheory`) and the code is in a branch called `gh-pages` (as it already was) then all forks of the main repo will get their own Github pages version of the site deployed at {{ username}}.github.io/openmusictheory.  See mine here: http://elliotthauser.com/openmusictheory/

(it's shown at elliotthauser.com because I use forwarding for my main site, eah13.github.io)

This should help with your goal of easy customization for those not so familiar with web dev.  Simple customizations can be made right in the browser, using Github's editor, and the new author can just just Github Pages as their class site.

Hope that helps!  I can write a n00b-friendly guide to forking and customizing the book on Github if that's helpful too.  Varibles like the name of the class or professor could be easily handled via config.yml, letting the book become a class website of sorts.
