### PR TITLE
Add Schenker trinket

### DIFF
--- a/cantusFirmus.md
+++ b/cantusFirmus.md
@@ -12,7 +12,7 @@ Exercises in strict voice-leading, or species counterpoint, begin with a single,
 
 Our first exercises in strict voice-leading will be to compose good, well formed *cantus firmi*. The first step is to perform and analyze model *cantus firmi*, such as the following *cantus firmus* in C major, composed by Heinrich Schenker.
 
-[![](Graphics/counterpoint/CF-Schenker.png)](Graphics/counterpoint/CF-Schenker.png)
+<iframe src="https://trinket.io/embed/music/da93d4d902" width="100%" height="200" frameborder="0" marginwidth="0" marginheight="0" allowfullscreen></iframe>
 
 A number of others are provided [here][CFs]. Performing these is a helpful practice to develop an internal sense of the sound and feel of a well formed *cantus*, and many of the characteristics of well formed *cantus firmi* carry over into other musical styles. (These model *cantus firmi* can also be used as the starting points for our two-voice exercises.)
 


### PR DESCRIPTION
Made the Schenker example on cantus firmus into a trinket instead of an image.

Got the alto clef, which was the non-obvious part.  Let me know if I mixed anything up :)
