### PR TITLE
Make width a percentage instead of hard coded

### DIFF
--- a/_sass/_styles.scss
+++ b/_sass/_styles.scss
@@ -186,7 +186,7 @@ input {
 }
 
 .wrap {
-    max-width: 960px;
+    max-width: 90%;
     @include column(10);
     float: none;
     margin: 0 auto;
@@ -196,7 +196,7 @@ input {
 
 .post {
     @include column(8);
-    max-width: 680px;
+    max-width: 80%;
     display: block;
     margin: 0 auto;
     float: none;


### PR DESCRIPTION
This is obviously very subjective but relative width pages are more idiomatic.  And I think they're easier to read YMMV :)
### Before:

![screenshot 2014-08-23 at 4 34 07 pm](https://cloud.githubusercontent.com/assets/1702745/4021793/dfdfba02-2b04-11e4-957e-a1d049681c8e.png)
### After:

![screenshot 2014-08-23 at 4 32 45 pm](https://cloud.githubusercontent.com/assets/1702745/4021788/cbb9e53e-2b04-11e4-9a45-6643ae672579.png)
